### PR TITLE
Update dead link (dactyl QMK guide)

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -1,4 +1,4 @@
-I built this keyboard following the [Dactyl QMK Guide](https://www.joedevivo.com/2017/05/20/building-a-qmk-dactyl.html) by Joe Devivo.
+I built this keyboard following the [Dactyl QMK Guide](https://www.joedevivo.com/2017-05-20-building-a-qmk-dactyl) by Joe Devivo.
  This is how I have built all of my Dactyl keyboards and allows me to build the firmware
  using the ErgodoxEZ online configurator which is now branded as [oryx](https://configure.ergodox-ez.com/).
 The guide can also be found directly in the [dactyl github repo](https://github.com/adereth/dactyl-keyboard/tree/master/qmk-guide).


### PR DESCRIPTION
The site doesn't support links with the .html extension anymore and the link formatting slightly changed